### PR TITLE
fix: cannot read property 'count' of null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ class Explosion extends React.PureComponent<Props, State> {
   };
 
   getItems = (prevColors: Array<string>): Array<Item> => {
-    const { count, colors = DEFAULT_COLORS } = this.props;
+    const { count, colors = DEFAULT_COLORS } = this.props ?? {count: undefined, colors: [""]};
     const { items } = this.state;
 
     const difference = items.length < count ? count - items.length : 0;


### PR DESCRIPTION
# Description

Fixed error which can occur during app entry.

### Related issues

- [X] [fixes this issue](https://github.com/VincentCATILLON/react-native-confetti-cannon/issues/90)
